### PR TITLE
Remove resume flag from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ pip install requests tqdm
 python GitSearch.py \
   --token $GITHUB_PAT \
   --dork "filename:.env DB_PASSWORD" \
-  --resume
 
 ```
 
@@ -122,7 +121,6 @@ pip install requests tqdm
 python GitSearch.py \
   --token $GITHUB_PAT \
   --dork "filename:.env DB_PASSWORD" \
-  --resume
 
 ```
 


### PR DESCRIPTION
## Summary
- update README usage examples to only mention `--token` and `--dork`

## Testing
- `git log -1 --stat`
